### PR TITLE
Support --no-progress to yarn_flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Configurable options:
 
 ```ruby
 set :yarn_target_path, -> { release_path.join('subdir') }  # default not set
-set :yarn_flags, '--production --pure-lockfile --no-emoji' # default
+set :yarn_flags, '--production --pure-lockfile --no-emoji --no-progress' # default
 set :yarn_roles, :all                                      # default
 set :yarn_env_variables, {}                                # default
 ```

--- a/lib/capistrano/tasks/yarn.rake
+++ b/lib/capistrano/tasks/yarn.rake
@@ -7,7 +7,7 @@ namespace :yarn do
         You can override any of these defaults by setting the variables shown below.
 
           set :yarn_target_path, nil
-          set :yarn_flags, '--production --pure-lockfile --no-emoji'
+          set :yarn_flags, '--production --pure-lockfile --no-emoji --no-progress'
           set :yarn_roles, :all
           set :yarn_env_variables, {}
     DESC
@@ -44,7 +44,7 @@ end
 
 namespace :load do
   task :defaults do
-    set :yarn_flags, %w(--production --pure-lockfile --no-emoji)
+    set :yarn_flags, %w(--production --pure-lockfile --no-emoji --no-progress)
     set :yarn_roles, :all
   end
 end


### PR DESCRIPTION
Progress bar is noisy.
I want support --no-progress.

Note: yarn install --no-progress includes bug.
https://github.com/yarnpkg/yarn/issues/1927

00:17 yarn:install
      01 yarn install --production
      01 yarn install v0.17.6
      01 [1/4] Resolving packages...
      01 [2/4] Fetching packages...
      01 ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0/33
      01 [3/4] Linking dependencies...
      01 ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0/33
      01 ████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░..
      01 █████████░░░░░░░░░░░░░░░░░░░░░░░░░░..
      01 █████████████░░░░░░░░░░░░░░░░░░░░░░..
      01 ███████████████████░░░░░░░░░░░░░░░░..